### PR TITLE
Fix the travis OSX build.

### DIFF
--- a/.travis/setup_osx.sh
+++ b/.travis/setup_osx.sh
@@ -3,8 +3,5 @@ set -e # Exit immediately if an error occurs.
 set -x # Echo commands.
 
 brew update
-# Install an updated CMake version.
-brew unlink cmake
-brew install cmake
-# Install Qt. Boost is already installed on the travis environment.
+# Install Qt. Boost and cmake are already installed on the travis environment.
 brew install qt5


### PR DESCRIPTION
With the recent OSX environment changes, a recent CMake version now
seems to be installed by default.
